### PR TITLE
修正学士论文摘要页码错误

### DIFF
--- a/template/thesis.typ
+++ b/template/thesis.typ
@@ -23,6 +23,8 @@
     中文扉页(info: info)
     英文扉页(info: info)
     独创性声明和论文使用授权(info: info)
+  } else {
+    pagebreak()
   }
 
   // 此时到了摘要页，需要重置页码为 1


### PR DESCRIPTION
学士论文环境下，由于摘要前没有 pagebreak，会导致摘要的页码将封面也计入，从 2 开始记起。

https://github.com/uestc-typst/thesis-template/blob/43378eff7a4d042c0301a80fdf4a47e9b19b5776/template/thesis.typ#L20-L29

此提交补上了缺失的 pagebreak，修复了这一问题。