### PR TITLE
模板调整

### DIFF
--- a/lib.typ
+++ b/lib.typ
@@ -1,3 +1,5 @@
 #import "template/consts.typ": info-keys, font-size
 #import "template/thesis.typ": thesis
 #import "template/tools/lib.typ": table-figure, code-figure, picture-figure
+#import "template/tools/term.typ": term, print-glossary
+#import "template/utils/ref.typ": c

--- a/template/component/前置-1-封面.typ
+++ b/template/component/前置-1-封面.typ
@@ -23,7 +23,7 @@
       info.at(info-keys.作者专业学位类别),
     )
   } else if info.at(info-keys.学位类型) == "学术型" {
-    justified-text-with-underline(4em, 16em, "学位类型", info.at(info-keys.作者专业学位类别))
+    justified-text-with-underline(4em, 16em, "学科专业", info.at(info-keys.作者学科专业))
   }
   #justified-text-with-underline(4em, 16em, "学号", info.at(info-keys.作者学号))
   #justified-text-with-underline(4em, 16em, "作者姓名", info.at(info-keys.作者中文名))
@@ -102,10 +102,10 @@
       // 需要换行且每一行都有下划线
       #if after-split.len() > 1 {
         for str in after-split {
-          fixed-width-underline(width: 20em, str)
+          fixed-width-underline(width: 18em, str)
         }
       } else if after-split.len() == 1 {
-        fixed-width-underline(width: 20em, after-split.at(0))
+        fixed-width-underline(width: 18em, after-split.at(0))
       }
     ]
   ]

--- a/template/component/前置-2-1-中文扉页.typ
+++ b/template/component/前置-2-1-中文扉页.typ
@@ -16,10 +16,10 @@
     #grid(
       columns: (1fr, 1fr),
       rows: (2em, 2em),
-      text("分类号") + fixed-width-underline(width: 15em, align(center, info.at(info-keys.分类号))),
-      text("密级") + fixed-width-underline(width: 15em, align(center, info.at(info-keys.密级))),
+      text("分类号") + fixed-width-underline(width: 14em, align(center, info.at(info-keys.分类号))),
+      text("密级") + fixed-width-underline(width: 14em, align(center, info.at(info-keys.密级))),
 
-      text()[UDC#super("注1")] + fixed-width-underline(width: 15em, align(center, info.at(info-keys.UDC))),
+      text()[UDC#super("注1")] + fixed-width-underline(width: 14em, align(center, info.at(info-keys.UDC))),
     )
   ]
 
@@ -57,13 +57,13 @@
 
   #v(3em)
 
-  #block(height: 80pt)[
+  #block(height: 60pt)[
     #block()[
       #grid(
         rows: (1fr, 1fr, 1fr),
         justified-text-with-underline(
           4em,
-          20em,
+          18em,
           "指导老师",
           align(
             center,
@@ -72,23 +72,23 @@
         ),
         justified-text-with-underline(
           4em,
-          20em,
+          18em,
           "",
           align(center, text(weight: "bold", info.at(info-keys.指导老师单位))),
         ),
-        justified-text-with-underline(
-          4em,
-          20em,
-          "合作导师",
-          align(
-            center,
-            text(weight: "bold", info.at(info-keys.合作导师中文名) + "   " + info.at(info-keys.合作导师职称中文)),
-          ),
-        ),
+        // justified-text-with-underline(
+        //   4em,
+        //   18em,
+        //   "合作导师",
+        //   align(
+        //     center,
+        //     text(weight: "bold", info.at(info-keys.合作导师中文名) + "   " + info.at(info-keys.合作导师职称中文)),
+        //   ),
+        // ),
         block()[
           #set text(size: font-size.小四)
           #fixed-width-text-justified(width: 4em, "")
-          #fixed-width-text(width: 20em, align(center)[（姓名、职称、单位名称）])
+          #fixed-width-text(width: 18em, align(center)[（姓名、职称、单位名称）])
         ],
       )
     ]
@@ -100,13 +100,13 @@
     columns: (1fr, 1fr),
     justified-text-with-underline(
       6em,
-      12em,
+      10em,
       "论文提交时间",
       align(center, text(weight: "bold", info.at(info-keys.提交日期))),
     ),
     justified-text-with-underline(
       6em,
-      12em,
+      9.5em,
       "论文答辩日期",
       align(center, text(weight: "bold", info.at(info-keys.答辩日期))),
     ),
@@ -114,21 +114,21 @@
 
   #let 授予单位与日期行 = justified-text-with-underline(
     9em,
-    28em,
+    24.5em,
     "学位授予单位和日期",
     align(center, text(weight: "bold", info.at(info-keys.学位授予单位) + "   " + info.at(info-keys.学位授予日期))),
   )
 
   #let 答辩委员会主席行 = justified-text-with-underline(
     7em,
-    30em,
+    26.5em,
     "答辩委员会主席",
     align(center, text(weight: "bold", info.at(info-keys.答辩委员会主席))),
   )
 
   #let 评阅人行 = justified-text-with-underline(
     3em,
-    34em,
+    30.5em,
     "评阅人",
     align(
       center,
@@ -146,13 +146,13 @@
           columns: (1fr, 1fr),
           justified-text-with-underline(
             6em,
-            12em,
+            10em,
             "申请学位级别",
             align(center, text(weight: "bold", info.at(info-keys.申请学位级别))),
           ),
           justified-text-with-underline(
             6em,
-            12em,
+            10em,
             "专业学位类别",
             align(center, text(weight: "bold", info.at(info-keys.作者专业学位类别))),
           ),
@@ -177,13 +177,13 @@
           columns: (1fr, 1fr),
           justified-text-with-underline(
             6em,
-            12em,
+            10em,
             "申请学位级别",
             align(center, text(weight: "bold", info.at(info-keys.申请学位级别))),
           ),
           justified-text-with-underline(
             4em,
-            12em,
+            11.5em,
             "学科专业",
             align(center, text(weight: "bold", info.at(info-keys.作者学科专业))),
           ),
@@ -206,14 +206,14 @@
   //     grid(
   //       inset: 0pt,
   //       columns: (1fr, 1fr),
-  //       justified-text-with-underline(6em, 12em, "申请学位级别", align(center, text(weight: "bold", info.at(info-keys.申请学位级别)))),
-  //       justified-text-with-underline(6em, 12em, "专业学位类别", align(center, text(weight: "bold", info.at(info-keys.作者专业学位类别)))),
+  //       justified-text-with-underline(6em, 10em, "申请学位级别", align(center, text(weight: "bold", info.at(info-keys.申请学位级别)))),
+  //       justified-text-with-underline(6em, 10em, "专业学位类别", align(center, text(weight: "bold", info.at(info-keys.作者专业学位类别)))),
   //     ),
   //     justified-text-with-underline(6em, 31em, "专业学位领域", align(center, text(weight: "bold", info.at(info-keys.专业学位领域)))),
   //     grid(
   //       columns: (1fr, 1fr),
-  //       justified-text-with-underline(6em, 12em, "论文提交时间", align(center, text(weight: "bold", info.at(info-keys.提交日期)))),
-  //       justified-text-with-underline(6em, 12em, "论文答辩日期", align(center, text(weight: "bold", info.at(info-keys.答辩日期)))),
+  //       justified-text-with-underline(6em, 10em, "论文提交时间", align(center, text(weight: "bold", info.at(info-keys.提交日期)))),
+  //       justified-text-with-underline(6em, 10em, "论文答辩日期", align(center, text(weight: "bold", info.at(info-keys.答辩日期)))),
   //     ),
   //     justified-text-with-underline(
   //       9em,

--- a/template/component/前置-2-2-英文扉页.typ
+++ b/template/component/前置-2-2-英文扉页.typ
@@ -31,7 +31,7 @@
     }
   ]
 
-  #v(16em)
+  #v(13em)
 
   #block(height: 140pt)[
     #set align(center)

--- a/template/component/前置-2-2-英文扉页.typ
+++ b/template/component/前置-2-2-英文扉页.typ
@@ -46,22 +46,22 @@
     #grid(
       columns: 1fr,
       rows: (1fr, 1fr, 1fr, 1fr, 1fr),
-      fixed-text-with-underline(7em, 28em, align(right)[Discipline], align(center, text(weight: "bold", 学科名称))),
+      fixed-text-with-underline(5em, 25em, align(right)[Discipline], align(center, text(weight: "bold", 学科名称))),
       fixed-text-with-underline(
-        7em,
-        28em,
+        5em,
+        25em,
         align(right)[Student ID],
         align(center, text(weight: "bold", info.at(info-keys.作者学号))),
       ),
       fixed-text-with-underline(
-        7em,
-        28em,
+        5em,
+        25em,
         align(right)[Author],
         align(center, text(weight: "bold", info.at(info-keys.作者英文名))),
       ),
       fixed-text-with-underline(
-        7em,
-        28em,
+        5em,
+        25em,
         align(right)[Supervisor],
         align(
           center,
@@ -69,8 +69,8 @@
         ),
       ),
       fixed-text-with-underline(
-        7em,
-        28em,
+        5em,
+        25em,
         align(right)[School],
         align(center, text(weight: "bold", info.at(info-keys.作者学院英文))),
       ),

--- a/template/component/前置-3-独创性声明和论文使用授权.typ
+++ b/template/component/前置-3-独创性声明和论文使用授权.typ
@@ -5,7 +5,7 @@
   // for debug
   #set block(stroke: if info.at(info-keys.DEBUG) { red } else { none })
 
-  #set par(first-line-indent: 2em, justify: true, leading: 1.5em, linebreaks: "optimized", spacing: 2em)
+  #set par(first-line-indent: 2em, justify: true, leading: 1.2em, linebreaks: "optimized", spacing: 2em)
   #set text(size: font-size.四号)
 
   #let 作者签名 = [#fixed-width-underline(

--- a/template/component/前置-4-摘要.typ
+++ b/template/component/前置-4-摘要.typ
@@ -21,12 +21,6 @@
     )
   }
 
-  context {
-    if calc.odd(here().page()) {
-      set page(header: none, footer: none, numbering: none)
-      counter(page).update(n => n - 1)
-    }
-  }
 }
 
 #let 中文摘要(info: (:)) = [

--- a/template/component/前置-5-目录.typ
+++ b/template/component/前置-5-目录.typ
@@ -5,7 +5,7 @@
   #set align(center)
   
   #set par(leading: above-leading-space()) // 设置条目行距
-  #set outline.entry(fill: repeat(text(top-edge: 0em)[.], gap: 0.15em))
+  #set outline.entry(fill: repeat(text(top-edge: 0em, bottom-edge: -0.3em)[.], gap: 0.1em))
 
   #show outline.entry.where(level: 1): it => {
     let prefix = if it.prefix() != none {

--- a/template/component/前置-5-目录.typ
+++ b/template/component/前置-5-目录.typ
@@ -1,33 +1,26 @@
 #import "../consts.typ": *
+#import "../tools/figure-i.typ": *
 
 #let 目录(info: (:)) = [
   #set align(center)
+  
+  #set par(leading: above-leading-space()) // 设置条目行距
+  #set outline.entry(fill: repeat(text(top-edge: 0em)[.], gap: 0.15em))
 
   #show outline.entry.where(level: 1): it => {
-    let prev-body = query(selector(heading.where(level: 1)))
-      .filter(h => h.outlined)
-      .filter(h => { h.location().page() <= it.element.location().page() })
-      .last()
-
-    let num-str = counter(heading).at(prev-body.location()).first()
-    let title-with-num = it.body()
-
-    if it.element.numbering != none {
-      title-with-num = numbering(it.element.numbering, num-str) + h(0.5em) + it.body()
-    }
-
-    box(
-      grid(
-        columns: (auto, 1fr, auto),
-        link(it.element.location())[
-          #text(weight: "bold", font: info.at(info-keys.黑体字体))[ #title-with-num ]
-        ],
-        it.fill,
-        it.page(),
-      ),
+    let prefix = if it.prefix() != none {
+        strong(it.prefix())
+      } else {
+        h(-0.5em)
+      }
+    it.indented(
+      prefix,
+      [#strong(it.body())
+       #box(width: 1fr, it.fill)
+       #it.page()],
+      gap: 0.5em
     )
   }
-
   #heading("目 录")
   #outline(title: none, depth: 3, indent: 2em)
 

--- a/template/component/前置-6-图表目录.typ
+++ b/template/component/前置-6-图表目录.typ
@@ -15,9 +15,11 @@
     let final-width = calc.max(size_abs.width, size.width)
     box(width: final-width, body)
   }
+  let num-total = counter(it.element.kind + "total").get().first()
+  counter(it.element.kind + "total").step()
   let head-num = counter(heading).at(it.element.location()).first()
   let element-num = counter(it.element.kind + str(head-num)).at(it.element.location()).first()
-  if head-num != 1 and element-num != 0 {
+  if num-total != 0 and element-num == 0 {
     v(12pt)
   }
   link(it.element.location())[

--- a/template/component/前置-6-图表目录.typ
+++ b/template/component/前置-6-图表目录.typ
@@ -3,25 +3,43 @@
 #import "../tools/figure-i.typ": *
 
 #let 图表目录(info: (:)) = [
+  #set outline.entry(fill: repeat(text(top-edge: 0em, bottom-edge: -0.3em)[.], gap: 0.1em))
 
-#set par(leading: above-leading-space())
 #show outline.entry: it => {
   // 定义空隙宽度，方便统一调整
-  let gap = 1.5em 
+  // let gap = 1.5em 
+
+  let min-box(min-width: 0pt, body) = context {
+    let size = measure(body)
+    let size_abs = measure(h(min-width))
+    let final-width = calc.max(size_abs.width, size.width)
+    box(width: final-width, body)
+  }
+  let head-num = counter(heading).at(it.element.location()).first()
+  let element-num = counter(it.element.kind + str(head-num)).at(it.element.location()).first()
+  if head-num != 1 and element-num != 0 {
+    v(12pt)
+  }
   link(it.element.location())[
     #grid(
-      columns: (3.5em, 1fr, gap),
+      // columns: (auto, 1fr, gap),
+      columns: (auto, 1fr),
       // stroke: 0.5pt,
       gutter: 0pt, // 关键：左右栏必须紧贴，物理间隙为0
-      it.prefix(),
-      [#it.body()
-       #box(width: 1fr, clip: false)[
-            #box(width: 100% + gap)[
-                  #set text(top-edge: 0em)
-                  #box(width: 1fr, it.fill)
+      min-box(min-width: 3.5em)[#it.prefix()],
+      [#set par(justify: true)
+       #it.body()
+        // #set text(top-edge: 0em, bottom-edge: 0.0em) // box会跟字体基线相同。文中设置了-0.2em，因此内部内容要设置为0
+      //  #box(width: 1fr, clip: false)[
+            // #box(width: 100% + gap)[
+            // #box(width: 1fr)[
+                  #box(width: 1fr)[
+                    #set text(top-edge: 0em, bottom-edge: -0.25em)
+                    #it.fill
+                  ]
                   #it.page()
-              ]
-          ]
+              // ]
+          // ]
       ]
     )
   ]

--- a/template/component/前置-6-图表目录.typ
+++ b/template/component/前置-6-图表目录.typ
@@ -1,4 +1,44 @@
 // https://github.com/typst/typst/discussions/4515
 #import "../consts.typ": *
+#import "../tools/figure-i.typ": *
 
-#let 图表目录(info: (:)) = []
+#let 图表目录(info: (:)) = [
+
+#set par(leading: above-leading-space())
+#show outline.entry: it => {
+  // 定义空隙宽度，方便统一调整
+  let gap = 1.5em 
+  link(it.element.location())[
+    #grid(
+      columns: (3.5em, 1fr, gap),
+      // stroke: 0.5pt,
+      gutter: 0pt, // 关键：左右栏必须紧贴，物理间隙为0
+      it.prefix(),
+      [#it.body()
+       #box(width: 1fr, clip: false)[
+            #box(width: 100% + gap)[
+                  #set text(top-edge: 0em)
+                  #box(width: 1fr, it.fill)
+                  #it.page()
+              ]
+          ]
+      ]
+    )
+  ]
+}
+  #outline(
+    title: "插图清单", 
+    target: figure.where(kind: figure-kind-pic),
+    indent: 2em, // 这是一个排版优化，让条目稍微缩进一点
+  )
+  #outline(
+    title: "表格清单", 
+    target: figure.where(kind: figure-kind-tbl),
+    indent: 2em
+  )
+  
+  #pagebreak(weak: true)
+  #if info.at(info-keys.打印模式) {
+    pagebreak(weak: true, to: "odd")
+  }
+]

--- a/template/component/前置-7-缩略词表等注释表.typ
+++ b/template/component/前置-7-缩略词表等注释表.typ
@@ -1,3 +1,17 @@
 #import "../consts.typ": *
+#import "../tools/term.typ": *
 
-#let 缩略词表等注释表(info: (:)) = []
+#let 缩略词表等注释表(info: (:)) = [
+  // #pagebreak()
+  // #set align(center)
+  // #set heading(supplement: "术语表", numbering: none, outlined: false)
+  // = 术语表
+
+  // #set align(left)
+  // #print-glossary()
+
+  // #pagebreak(weak: true)
+  // #if info.at(info-keys.打印模式) {
+  //   pagebreak(weak: true, to: "odd")
+  // }
+]

--- a/template/thesis.typ
+++ b/template/thesis.typ
@@ -39,6 +39,7 @@
   show: set-英文摘要-page.with()
   英文摘要(info: info)
 
+  show: commen-space-set.with()
   show: set-目录-heading.with()
   show: set-目录-page.with()
   目录(info: info)
@@ -46,7 +47,6 @@
   缩略词表等注释表(info: info)
 
   // 此时到了正文页，需要重置页码为 1
-  show: 正文-space-set.with()
   counter(page).update(1)
   show: set-正文-heading.with()
   show: set-正文-page.with()

--- a/template/thesis.typ
+++ b/template/thesis.typ
@@ -9,13 +9,15 @@
   let info = info-check(info: info)
   let degree = info.at(info-keys.申请学位级别)
   [#metadata(degree) <学位>]
-
+  show: set-global-page.with()
   show: set-font.with(info)
   show: common-set.with(info)
+  show: 其他-space-set.with()
   show: figure-env-set.with()
   show: set-global-heading.with(info)
   show: set-footnote.with()
   show: set-ref.with()
+  show: set-equation.with()
 
   封面(info: info)
   if degree != "学士" {
@@ -44,6 +46,7 @@
   缩略词表等注释表(info: info)
 
   // 此时到了正文页，需要重置页码为 1
+  show: 正文-space-set.with()
   counter(page).update(1)
   show: set-正文-heading.with()
   show: set-正文-page.with()

--- a/template/tools/figure-i.typ
+++ b/template/tools/figure-i.typ
@@ -1,4 +1,5 @@
 #import "../consts.typ": *
+#import "../utils/word_spacing.typ": above-leading-space, below-leading-space, 单倍行距
 #let figure-kind-code = "figure-kind-code"
 #let figure-kind-pic = "figure-kind-pic"
 #let figure-kind-tbl = "figure-kind-tbl"
@@ -11,20 +12,45 @@
   // 利用 box 的自动伸缩来实现
   // 只有一行的时候居中
   // 多行左对齐
-  show figure.caption: it => box(box(align(left, it)), width: 80%)
-
+   show figure: set figure(gap: 6pt)
   // 显示的前后边距
   let figure-body(it) = {
-    v(1em)
+    set par(leading: above-leading-space())
     it
-    v(1.5em)
   }
-
+  // show figure: set block(above: 2em, below: 2em)
+  // 图的整体间距：段前 6pt (段后由 caption 控制)
+  show figure.where(kind: figure-kind-pic): set block(above: above-leading-space(space: 6pt, word-space: 单倍行距), below: below-leading-space(12pt))
+  show figure.where(kind: figure-kind-tbl): set block(above: above-leading-space(space: 12pt, word-space: 单倍行距), below: below-leading-space(6pt))
   // figure 计数器自增函数
   // 图1-1 后变成 图1-2
   let count-step(kind) = {
     let chapter-num = counter(heading.where(level: 1)).display()
     counter(kind + str(chapter-num)).step()
+  }
+
+  show figure.caption: it => {
+    let indent-width = measure(h(4em)).width
+    let size = measure(it.body)
+    layout(bounds => {
+      let full-caption = if it.numbering != none {
+              [#it.supplement#it.counter.display(it.numbering)#h(0.5em)#it.body]
+            } else {
+              it.body
+            }
+      if size.width > bounds.width - indent-width * 2 {
+        set par(justify: true, leading: above-leading-space())
+        box(
+          width: 100%, 
+          inset: (x: indent-width), // 左右缩进
+          align(left, full-caption)      // 两端对齐基于左对齐基础
+        )
+      } else {
+        set par(leading: above-leading-space())
+        set align(center)
+        full-caption
+      }
+    })
   }
 
   show figure: it => {
@@ -71,7 +97,7 @@
   figure(code, caption: caption, supplement: [代码], numbering: code-numering, kind: figure-kind-code)
 }
 
-#let picture-figure(caption, picture) = {
-  figure(picture, caption: caption, supplement: [图], numbering: pic-numering, kind: figure-kind-pic)
+#let picture-figure(caption, picture, placement: none) = {
+  figure(picture, caption: caption, supplement: [图], numbering: pic-numering, kind: figure-kind-pic, placement: placement)
 }
 

--- a/template/tools/figure-i.typ
+++ b/template/tools/figure-i.typ
@@ -25,7 +25,7 @@
   // figure 计数器自增函数
   // 图1-1 后变成 图1-2
   let count-step(kind) = {
-    let chapter-num = counter(heading.where(level: 1)).display()
+    let chapter-num = counter(heading.where(level: 1)).get().first()
     counter(kind + str(chapter-num)).step()
   }
 
@@ -89,12 +89,12 @@
   numbering("1", counter(heading.where(level: 1)).get().first()) + "-" + str(int(type-num) + 1)
 }
 
-#let table-figure(caption, table) = {
-  figure(table, caption: caption, supplement: [表], numbering: tbl-numering, kind: figure-kind-tbl)
+#let table-figure(caption, table, placement: none) = {
+  figure(table, caption: caption, supplement: [表], numbering: tbl-numering, kind: figure-kind-tbl, placement: placement)
 }
 
-#let code-figure(caption, code) = {
-  figure(code, caption: caption, supplement: [代码], numbering: code-numering, kind: figure-kind-code)
+#let code-figure(caption, code, placement: none) = {
+  figure(code, caption: caption, supplement: [代码], numbering: code-numering, kind: figure-kind-code, placement: placement)
 }
 
 #let picture-figure(caption, picture, placement: none) = {

--- a/template/tools/fixed-witdh-content.typ
+++ b/template/tools/fixed-witdh-content.typ
@@ -11,11 +11,16 @@
 // [     类似这样     ]
 //  _________________
 #let fixed-width-underline(width: auto, height: auto, body) = box(
-  body,
   width: width,
-  height: height,
   stroke: (bottom: 0.5pt),
-  outset: (bottom: 0.3em),
+  outset: (bottom: 0.2em),
+  height: height,
+  {
+    // 这里设置行间距
+    // 默认 leading 大约是 0.65em
+    set par(leading: 0.5em) 
+    body
+  }
 )
 
 // 占 width 的宽度, 其中包含一些字符

--- a/template/tools/term.typ
+++ b/template/tools/term.typ
@@ -1,0 +1,62 @@
+#let term-state = state("glossary-terms", ())
+
+// 函数：输入中文和英文，文中显示 "中文 (英文)" 并后台记录
+#let term(cn, en) = {
+  // 1. 在文中显示文本
+  cn + "（" + en + "）"
+
+  // 2. 获取当前位置并更新状态
+  context {
+    let loc = here() // 获取当前函数被调用时的位置对象
+    
+    term-state.update(terms => {
+      // 检查是否已存在（只记录首次出现，因此如果存在则忽略）
+      if terms.any(t => t.cn == cn) {
+        terms
+      } else {
+        // 将中文、英文、以及当前的位置(loc)一起存入
+        terms.push((cn: cn, en: en, loc: loc))
+        terms
+      }
+    })
+  }
+}
+
+#let print-glossary() = {
+  context {
+    let terms = term-state.final()
+    // 按英文首字母排序
+    let sorted-terms = terms.sorted(key: t => lower(t.en))
+
+    if sorted-terms.len() == 0 {
+      [暂无术语记录。]
+    } else {
+      // 设置表格样式（这里用了典型的学术三线表风格）
+      table(
+        columns: (1fr, 2fr, auto), // 三列：中文、英文、页码
+        inset: 5pt,
+        align: (col, row) => (right, left, center).at(col),
+        stroke: (x, y) => {
+          if y == 0 { (bottom: 1pt) } // 表头下粗线
+          else { (bottom: 0.5pt + gray) } // 内容下细线
+        },
+        
+        // 表头
+        [*中文名称*], [*英文全称*], [*首次出现*],
+        
+        // 数据填充
+        ..sorted-terms.map(item => {
+          // 获取该位置的页码
+          let page-num = item.loc.page()
+          
+          (
+            item.cn, 
+            item.en, 
+            // 创建一个链接，点击页码跳回原文位置
+            link(item.loc)[第 #page-num 页]
+          )
+        }).flatten()
+      )
+    }
+  }
+}

--- a/template/utils/common.typ
+++ b/template/utils/common.typ
@@ -1,23 +1,22 @@
 #import "info.typ": *
 #import "font.typ": *
+#import "word_spacing.typ": above-leading-space, below-leading-space
 
-// 字体 段落 加粗信息等设置
 #let common-set(info, body) = {
-  set par(
-    first-line-indent: (amount: 2em, all: true),
-    justify: true,
-    leading: 0.80em,
-    spacing: 0.80em,
-  )
-
-  set text(
-    region: "cn",
-    lang: "zh",
-    font: info.at(info-keys-private.字体).宋体,
-    size: font-size.小四,
-  )
-
+  set par(first-line-indent: (amount: 2em, all: true), justify: true)
+  set text(region: "cn", lang: "zh", font: info.at(info-keys-private.字体).宋体, size: font-size.小四)
+  // set text(top-edge: "ascender", bottom-edge: "descender")
+  set text(top-edge: 0.8em, bottom-edge: -0.2em)
   set strong(delta: info.at(info-keys.加粗粗度))
+  body
+}
 
+#let 正文-space-set(body) = {
+  set par(first-line-indent: (amount: 2em, all: true), justify: true, leading: above-leading-space(), spacing: above-leading-space())
+  body
+}
+
+#let 其他-space-set(body) = {
+  set par(leading: 1em, spacing: 1em)
   body
 }

--- a/template/utils/common.typ
+++ b/template/utils/common.typ
@@ -11,12 +11,12 @@
   body
 }
 
-#let 正文-space-set(body) = {
+#let commen-space-set(body) = {
   set par(first-line-indent: (amount: 2em, all: true), justify: true, leading: above-leading-space(), spacing: above-leading-space())
   body
 }
 
 #let 其他-space-set(body) = {
-  set par(leading: 1em, spacing: 1em)
+  set par(leading: 1em, spacing: 1em, justify: true)
   body
 }

--- a/template/utils/equation.typ
+++ b/template/utils/equation.typ
@@ -1,0 +1,51 @@
+#import "../utils/word_spacing.typ": above-leading-space, below-leading-space, 单倍行距
+#import "../consts.typ": *
+
+
+#let equation-code = "equation-code"
+
+#let code-numering(_) = {
+  let chapter-num = counter(heading.where(level: 1)).display()
+  // set text(top-edge: "cap-height", bottom-edge: "baseline")
+  let type-num = counter(equation-code + chapter-num).display()
+  let num-str = "(" + numbering("1", counter(heading.where(level: 1)).get().first()) + "-" + str(int(type-num) + 1) + ")"
+  num-str
+}
+
+#let set-equation(body) = {
+  set math.equation(
+    numbering: code-numering, 
+    supplement: [式],
+    number-align: horizon,
+  )
+
+  show math.equation.where(block: true): it => {
+    let formatting = math.equation(numbering: none, it.body)
+    set text(size: font-size.小四)
+
+    let eqNumbering = none
+    if it.has("label"){
+      let eqCounter = counter(math.equation).at(it.location())
+      eqNumbering = numbering(it.numbering, ..eqCounter)
+    }
+    
+    // 设置公式内部行距 (防止切断积分号)
+    set par(leading: 单倍行距)
+
+    block(
+      width: 100%, 
+      inset: 0pt, // 确保没有额外内边距
+      above: above-leading-space(space: 6pt, word-space: 单倍行距),
+      below: below-leading-space(6pt),
+      grid(
+          columns: (1fr, auto, 1fr),
+          [],
+          align(horizon)[
+              #formatting
+            ],
+          align(right + horizon)[#eqNumbering],
+        )
+    )
+  }
+  body
+}

--- a/template/utils/heading.typ
+++ b/template/utils/heading.typ
@@ -1,6 +1,7 @@
 #import "../tools/lib.typ": *
 #import "info.typ": *
 #import "font.typ": *
+#import "word_spacing.typ": above-leading-space, below-leading-space, heading-1, heading-2, heading-3, heading-4, word-below-leading-space, word-leading-space
 
 #let supplement-中文摘要 = "中文摘要"
 #let supplement-英文摘要 = "英文摘要"
@@ -11,38 +12,115 @@
 #let supplement-参考文献 = "参考文献"
 #let supplement-攻读学位期间取得成果 = "攻读学位期间取得成果"
 
+// --- 定义状态变量 ---
+#let last-heading-level = state("last-heading-info", (level: 0, excess: 0pt))
+
 #let set-global-heading(info, body) = {
-  show heading.where(level: 1): it => {
-    pagebreak(weak: true)
+  // --- 1. 状态重置机制 ---
+  // 遇到正文、图表、公式时，标记"上一个元素不是标题"
+  show par: it => { last-heading-level.update((level: 0, excess: 0pt)); it }
+  show figure: it => { last-heading-level.update((level: 0, excess: 0pt)); it }
+  show math.equation.where(block: true): it => { last-heading-level.update((level: 0, excess: 0pt)); it }
+  show list: it => { last-heading-level.update((level: 0, excess: 0pt)); it }
+  show enum: it => { last-heading-level.update((level: 0, excess: 0pt)); it }
+
+  // --- 2. 一级标题 (通常强制分页，只需更新状态) ---
+  show heading.where(level: 1): it => context {
+    // 一级标题强制分页，不需要判断 above 为 0，但需要更新状态供二级标题检测
+    last-heading-level.update((level: 1, excess: heading-1.below - 
+                                                 below-leading-space(heading-1.below)
+                                                 ))
+
+    pagebreak(weak: false)
     set text(size: font-size.小三, font: get-hei-font(info))
     set align(center)
-    v(24pt)
-    it
-    v(18pt)
+    if it.numbering != none {
+      block(
+        width: 100%,
+        above: heading-1.above,
+        below: below-leading-space(heading-1.below), 
+        sticky: true,
+        inset: (top: heading-1.above),
+      )[
+        #counter(heading).display(it.numbering)#h(0.5em)#it.body
+      ]
+    } else {
+      v(heading-1.above)
+      it
+      v(heading-1.below)
+    }
   }
 
-  show heading.where(level: 2): it => {
+  // --- 3. 二级标题 (需要判断是否紧跟一级标题) ---
+  show heading.where(level: 2): it => context {
+    let prev-level = last-heading-level.get().level
+    // 如果上一个是标题，则段前为 0；否则使用默认值
+    let spacing-above = if prev-level > 0 { 0pt } else { above-leading-space(space: heading-2.above) }
+
+    // 渲染前先更新状态 (放在 block 后面也行，但 context 内通常顺序执行)
+    last-heading-level.update((level: 2, excess: heading-2.below - 
+                                                  below-leading-space(heading-2.below)))
+
     set align(left)
     set text(size: font-size.四号, font: get-hei-font(info))
-    v(18pt)
-    it
-    v(6pt)
+
+    if last-heading-level.get().excess != 0pt {
+      v(last-heading-level.get().excess + above-leading-space())
+    }
+    block(
+      width: 100%,
+      above: spacing-above, // <--- 应用动态间距
+      sticky: true,
+      below: below-leading-space(heading-2.below), 
+    )[
+      #counter(heading).display(it.numbering)#h(0.5em)#it.body
+    ]
   }
 
-  show heading.where(level: 3): it => {
+  // --- 4. 三级标题 (需要判断是否紧跟二级标题) ---
+  show heading.where(level: 3): it => context {
+    let prev-level = last-heading-level.get().level
+    let spacing-above = if prev-level > 0 { 0pt } else { above-leading-space(space: heading-3.above) }
+    
+    last-heading-level.update((level: 3, excess: heading-3.below - 
+                                                  below-leading-space(heading-3.below)))
+
     set align(left)
     set text(size: font-size.四号, font: get-hei-font(info))
-    v(12pt)
-    it
-    v(6pt)
+    if last-heading-level.get().excess != 0pt {
+      v(last-heading-level.get().excess + above-leading-space())
+    }
+    block(
+      width: 100%,
+      above: spacing-above, // <--- 应用动态间距
+      sticky: true,
+      below: below-leading-space(heading-3.below), 
+    )[
+      #counter(heading).display(it.numbering)#h(0.5em)#it.body
+    ]
   }
 
-  show heading.where(level: 4): it => {
+  // --- 5. 四级标题 ---
+  show heading.where(level: 4): it => context {
+    let prev-level = last-heading-level.get().level
+    let spacing-above = if prev-level > 0 { 0pt } else { above-leading-space(space: heading-4.above) }
+    
+    last-heading-level.update((level: 4, excess: heading-4.below - 
+                                                  below-leading-space(heading-4.below)))
+
     set align(left)
     set text(size: font-size.小四, font: get-hei-font(info))
-    v(12pt)
-    it
-    v(6pt)
+    if last-heading-level.get().excess != 0pt {
+      v(last-heading-level.get().excess + above-leading-space())
+    }
+    block(
+      width: 100%,
+      above: spacing-above, // <--- 应用动态间距
+      sticky: true,
+      below: below-leading-space(heading-4.below), 
+    )[
+      #counter(heading).display(it.numbering)#h(0.5em)#it.body
+    ]
   }
 
   body
@@ -71,7 +149,7 @@
       if n == 1 {
         numbering("第一章", ..nums)
       } else {
-        numbering("1.1.1", ..nums)
+        numbering("1.1.1.1", ..nums)
       }
     },
   )

--- a/template/utils/lib.typ
+++ b/template/utils/lib.typ
@@ -1,7 +1,7 @@
 #import "info.typ": info-default-kv, info-check
 
 #import "font.typ": get-song-font, get-hei-font, get-mono-font
-#import "common.typ": common-set, 正文-space-set, 其他-space-set
+#import "common.typ": common-set, commen-space-set, 其他-space-set
 
 #import "footnote.typ": set-footnote
 

--- a/template/utils/lib.typ
+++ b/template/utils/lib.typ
@@ -1,8 +1,7 @@
 #import "info.typ": info-default-kv, info-check
 
 #import "font.typ": get-song-font, get-hei-font, get-mono-font
-
-#import "common.typ": common-set
+#import "common.typ": common-set, 正文-space-set, 其他-space-set
 
 #import "footnote.typ": set-footnote
 
@@ -23,6 +22,7 @@
 )
 
 #import "page.typ": (
+  set-global-page,
   set-中文摘要-page,
   set-英文摘要-page,
   set-目录-page,
@@ -33,3 +33,6 @@
   set-攻读学位期间获取成果-page,
 )
 
+#import "equation.typ": (
+  set-equation,
+)

--- a/template/utils/page.typ
+++ b/template/utils/page.typ
@@ -1,5 +1,6 @@
 #import "info.typ": *
 #import "font.typ": *
+#import "@preview/hydra:0.6.2": hydra
 
 #let footer-罗马数字页码 = context {
   set align(center)
@@ -15,7 +16,7 @@
 #let header-help-func(str) = context {
   set align(center + bottom)
   set text(size: font-size.五号)
-  set par(spacing: 0.4em, leading: 0.3em)
+  set par(spacing: 0.2em, leading: 0.3em)
   // block(inset: 0pt, height: 90%, stroke: red)[
   block(inset: 0pt, height: 90%)[
     #text(str)
@@ -32,92 +33,45 @@
 }
 
 #let header-中文摘要 = header-with-text("摘 要")
+
 #let header-英文摘要 = header-with-text("ABSTRACT")
+
 #let header-目录 = header-with-text("目 录")
+
 #let header-正文 = context {
   let txt = "电子科技大学" + query(<学位>).first().value + "学位论文"
   let body-page = counter(page).get().at(0, default: 0)
   // 奇数页为内容
   if calc.odd(body-page) {
-    let is-heading-1-page = false
-    let h = query(heading.where(level: 1).after(here()))
-      .filter(h => { h.location().page() == here().page() })
-      .at(0, default: none)
-    if h != none {
-      is-heading-1-page = true
-    } else {
-      h = query(heading.where(level: 1).before(here())).at(-1, default: none)
-    }
-    if h != none {
-      let cnt = counter(heading).at(here()).at(0, default: 1)
-      if is-heading-1-page {
-        cnt = cnt + 1
-      }
-
-      let num = if h.numbering != none {
-        h.numbering
-      } else {
-        none
-      }
-
-      let title-body = h.body
-      if num == none {
-        txt = title-body
-      } else {
-        txt = numbering(num, cnt) + " " + title-body
-      }
-    }
+    txt = hydra(1, skip-starting: false, use-last: true)
   }
-
   header-help-func(txt)
 }
 
 #let header-致谢 = header-with-text("致 谢")
 
-#let thesis-margin = (top: 30mm, bottom: 30mm)
-#let thesis-header-ascent = 20%
+#let set-global-page(body) = {
+  set page(paper: "a4", header: none, footer: none, margin: (top: 3cm, right: 3cm, bottom: 3cm, left: 3cm), header-ascent: 1cm - font-size.小五 - 4.5pt, footer-descent: 1cm - font-size.小五)
+  body
+}
 
 #let set-中文摘要-page(body) = {
-  set page(
-    header: header-中文摘要,
-    header-ascent: thesis-header-ascent,
-    footer: footer-罗马数字页码,
-    paper: "a4",
-    margin: thesis-margin,
-  )
+  set page(header: header-中文摘要, footer: footer-罗马数字页码)
   body
 }
 
 #let set-英文摘要-page(body) = {
-  set page(
-    header: header-英文摘要,
-    header-ascent: thesis-header-ascent,
-    footer: footer-罗马数字页码,
-    paper: "a4",
-    margin: thesis-margin,
-  )
+  set page(header: header-英文摘要, footer: footer-罗马数字页码)
   body
 }
 
 #let set-目录-page(body) = {
-  set page(
-    header: header-目录,
-    header-ascent: thesis-header-ascent,
-    footer: footer-罗马数字页码,
-    paper: "a4",
-    margin: thesis-margin,
-  )
+  set page(header: header-目录, footer: footer-罗马数字页码)
   body
 }
 
 #let set-正文-page(body) = {
-  set page(
-    header: header-正文,
-    header-ascent: thesis-header-ascent,
-    footer: footer-阿拉伯数字页码,
-    paper: "a4",
-    margin: thesis-margin,
-  )
+  set page(header: header-正文, footer: footer-阿拉伯数字页码)
   body
 }
 

--- a/template/utils/ref.typ
+++ b/template/utils/ref.typ
@@ -20,3 +20,8 @@
   }
   body
 }
+
+#let c(..keys) = {
+  show super: it => it.body
+  keys.pos().map(k => cite(k)).join()
+}

--- a/template/utils/word_spacing.typ
+++ b/template/utils/word_spacing.typ
@@ -1,0 +1,33 @@
+#import "../consts.typ": *
+
+// 字体 段落 加粗信息等设置
+#let leading-space = 20pt
+#let 单倍行距 = 0.25em
+#let word-leading-space = leading-space - 1em
+#let word-below-leading-space = leading-space - font-size.小四
+#let above-leading-space(space: 0pt, word-space: word-leading-space) = {
+  word-space + space
+}
+#let below-leading-space(space) = {
+  word-below-leading-space + space
+}
+
+#let heading-1 = (
+  above: 24pt,
+  below: 18pt,
+)
+
+#let heading-2 = (
+  above: 18pt,
+  below: 6pt,
+)
+
+#let heading-3 = (
+  above: 12pt,
+  below: 6pt,
+)
+
+#let heading-4 = (
+  above: 12pt,
+  below: 6pt,
+)


### PR DESCRIPTION
1. 封面页边距也改成了3cm。
2. 正文的行距通过设置par(top-edge: 0.8em, bottom-edge: -0.2em),text(leading: 20pt - 1em)设置为与word相同。
3. 调整标题格式，相邻标题自动去掉段前距。标题段前段后距离调整。
4. 调整图和表的caption的格式。包括行距，段前段后距等。
5. 添加图表目录。
6. 添加了术语。通过#term("中文", "英文")自动添加术语页。正文中显示为“中文（英文）“。
7. 目录细节调整，严格符合20磅行距。
8. 摘要不收敛bug修复。
9. 页脚页眉微调，符合上下都为2cm。
10. 引用通过#c()函数可以实现不上标。
11. 公式环境支持，添加引用之后，自动添加标号。如果没有引用则没有标号。